### PR TITLE
NXP-23921 reverting template for lambda contribution

### DIFF
--- a/marketplace/src/main/resources/install/templates/lambda/config/nuxeo-lambda-picture-gen-contrib.xml
+++ b/marketplace/src/main/resources/install/templates/lambda/config/nuxeo-lambda-picture-gen-contrib.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.lambda.picture.view.generator.contrib">
+
+  <require>org.nuxeo.lambda.picture.aws.config</require>
+  <extension target="org.nuxeo.lambda.core.LambdaService" point="lambdaConfiguration">
+    <lambdaConfigs name="${nuxeo.lambda.image.conversion}" class="org.nuxeo.lambda.aws.AWSLambdaCaller">
+      <onSuccessEvent>afterLambdaPictureResponse</onSuccessEvent>
+      <onErrorEvent>lambdaPictureFailed</onErrorEvent>
+    </lambdaConfigs>
+  </extension>
+
+</component>

--- a/marketplace/src/main/resources/install/templates/lambda/nuxeo.defaults
+++ b/marketplace/src/main/resources/install/templates/lambda/nuxeo.defaults
@@ -1,0 +1,2 @@
+## Set name of the function used at AWS
+nuxeo.lambda.image.conversion=nuxeo-lambda-picture


### PR DESCRIPTION
Lambda core requires a lambda config configuration. The template in this marketplace package contributes such xml extension. 